### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/amureika/c071fff7-4f85-4d28-9ca5-8482c6e1b85d/cb6ecef4-648a-4f2d-a512-51f5bd75bd09/_apis/work/boardbadge/ce558259-6517-40fc-8dac-1c57ab20dbbb)](https://dev.azure.com/amureika/c071fff7-4f85-4d28-9ca5-8482c6e1b85d/_boards/board/t/cb6ecef4-648a-4f2d-a512-51f5bd75bd09/Microsoft.RequirementCategory)
 # MyPortfolio
 Website displaying information about me and some examples of work and projects.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/amureika/c071fff7-4f85-4d28-9ca5-8482c6e1b85d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.